### PR TITLE
Enkel Tooltip komponent (aka "hover text box" for å forklare konsepter)

### DIFF
--- a/opplaering/index.mdx
+++ b/opplaering/index.mdx
@@ -8,6 +8,7 @@ import Gaming from "../static/img/gaming.svg";
 import { UtdanningNoBox } from "../src/components/UtdanningNoBox/UtdanningNoBox.tsx";
 import { RelevantLinks } from "../src/components/RelevantLinks/RelevantLinks.tsx";
 import { FagomraderQuiz } from "../src/components/FagomraderQuiz/FagomraderQuiz.tsx";
+import { Tooltip } from "../src/components/Tooltip/Tooltip.tsx";
 
 # Finn ditt fagområde
 
@@ -22,7 +23,7 @@ Det er viktig å finne ut hvilket fagområde du ønsker å jobbe innenfor. Her e
 Frontend utviklere jobber på å implementere design og brukergrensesnitt, som regel nettsider og apper.
 Hvis du har et øye for design og liker å jobbe med brukergrensesnitt, så er frontend utvikling noe for deg.
 
-Deler av jobben innebærer å jobbe med designere og UX-ere for å lage gode brukeropplevelser,
+Deler av jobben innebærer å jobbe med designere og <Tooltip hint="UX = User eXperience designer. Disse utvikler en brukeropplevelse ved å lage prototyper, tenke ut ulike bruksmønstre osv.">UX-ere</Tooltip> for å lage gode brukeropplevelser,
 og å jobbe med backend utviklere for å få systemene til å henge sammen.
 
 Det er også viktig å ha god forståelse for hvordan brukere bruker systemene, og å teste at systemene er tilgjengelige

--- a/ressurser/artikler/byggesystem.mdx
+++ b/ressurser/artikler/byggesystem.mdx
@@ -3,6 +3,7 @@ description: Et byggesystem håndterer bygging av koden din, avhengigheter den m
 ---
 
 import { RelevantLinks } from "../../src/components/RelevantLinks/RelevantLinks.tsx";
+import { Tooltip } from "../../src/components/Tooltip/Tooltip.tsx";
 
 # Byggesystem
 Et byggesystem håndterer bygging/kompilering av koden din, avhengigheter den måtte ha, og andre lignende oppgaver.
@@ -20,7 +21,7 @@ flowchart LR
 
 
 ### Hvorfor bruke et byggesystem?
-Du har kanskje laget ganske enkle applikasjoner hittil? Du vil nok legge merke til at kommandoene for å kompilere blir stadig mer komplekse når du har flere filer. Det er flere grunner til å bruke et byggesystem:
+Du har kanskje laget ganske enkle applikasjoner hittil? Du vil nok legge merke til at kommandoene for å <Tooltip hint="Å kompilere kode betyr overforenklet å oversette koden fra tekst vi kan lese, til instrukser maskinen kan utføre.">kompilere</Tooltip> blir stadig mer komplekse når du har flere filer. Det er flere grunner til å bruke et byggesystem:
 - Prosjektet har mange kodefiler som skal bygges/kompileres.
 - Prosjektet avhenger av eksterne avhengigheter som f.eks web server logikk eller sikkerhets-algoritmer. Disse avhengighetene kan fort bli litt tuklete å håndtere manuelt.
 - Håndtering av versjonsnummer for prosjektet

--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -1,0 +1,35 @@
+.tooltip {
+    display: inline-block;
+    margin: 0;
+    position: relative;
+    border-bottom: 1px dotted gray;
+}
+
+.hint {
+    display: inline-block;
+    visibility: hidden;
+    z-index: 1;
+    position: absolute;
+    bottom: 120%;
+    right: -15%;
+    border: 2px dashed black;
+    border-radius: 5px;
+    background: white;
+    min-width: 15vw;
+    max-width: 40vw;
+    padding: 10px 10px 10px 10px;
+}
+
+.tooltip .hint::after {
+    content: " ";
+    position: absolute;
+    top: 100%;
+    right: 5%;
+    border-width: 10px;
+    border-style: dashed;
+    border-color: black transparent transparent transparent;
+}
+
+.tooltip:hover .hint {
+    visibility: visible;
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import styles from "./Tooltip.module.scss";
+
+export const Tooltip = ({children, hint}) => {
+    return (<span className={styles.tooltip}>
+        {children}
+        <span className={styles.hint}>{hint}</span>
+    </span>);
+};


### PR DESCRIPTION
Klødde i fingrene etter å leke med CSS av en eller annen rar grunn, så prøvde meg på en tooltip komponent 🙂 @aruudboy foreslo en slik enkel komponent i #20, men jeg fant ikke noe slik. Lagde også noen få enkle tooltip eksempler. F.eks denne i intro-siden om frontend:
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/6603173b-3a55-4b62-88d0-289fa7569a21">

Eller her i byggesystem artikkelen:
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/671ca72b-2dcd-4e20-b198-07214a53631a">

Bruk av denne tooltip komponenten er svært enkel. La oss si vi ønsket en tooltip for UX-ere teksten:
```html
<Tooltip hint="UX = User eXperience designer. Disse utvikler en brukeropplevelse ved å lage prototyper, tenke ut ulike bruksmønstre osv.">UX-ere</Tooltip>
```

Synes den ser helt ok ut. Sikkert forbedrings-potensiale, men synes å få opp noe som fungerer er bedre enn ingenting. Er selvfølgelig OK å avvise PR også, så no hard feelings on dette ikke faller i smak 🙂 Om den derimot er ok, så kan jeg gjerne oppdatere ved å lage flere tooltip-tekster til ulike konsepter jeg finner (eller får av forslag) 😄 


---
For sider som du (@imp-dance ) nevner i issue-tråden, altså å ha en forklaring med mulighet til å klikke videre til en egen side som beskriver, så kan vi kanskje bruke noe ala dette:
https://github.com/grnet/docusaurus-terminology
